### PR TITLE
Add Ctrl-p and Ctrl-n movement shortcuts.

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -198,6 +198,24 @@ bool Dialog::editKeyPressEvent(QKeyEvent *event)
 {
     switch (event->key())
     {
+    case Qt::Key_N:
+        if (event->modifiers().testFlag(Qt::ControlModifier))
+        {
+            QKeyEvent ev(QEventKeyPress, Qt::Key_Down, Qt::NoModifier);
+            editKeyPressEvent(&ev);
+            return true;
+        }
+            return false;
+
+    case Qt::Key_P:
+        if (event->modifiers().testFlag(Qt::ControlModifier))
+        {
+            QKeyEvent ev(QEventKeyPress, Qt::Key_Up, Qt::NoModifier);
+            editKeyPressEvent(&ev);
+            return true;
+        }
+            return false;
+
     case Qt::Key_Up:
     case Qt::Key_PageUp:
         if (ui->commandEd->text().isEmpty() &&


### PR DESCRIPTION
Ctrl-p moves the focus one item up and Ctrl-n moves the focus one item
down.
