### PR TITLE
Fixes translations install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ add_definitions(-Wall)
 find_package(X11 REQUIRED)
 include_directories(${X11_INCLUDE_DIR})
 
-set(LXQT_SHARE_DIR ${CMAKE_INSTALL_PREFIX}/share/lxqt)
 set(APP_SHARE_DIR ${LXQT_SHARE_DIR}/${PROJECT_NAME})
 
 #************************************************

--- a/cmake/LxQtTranslate.cmake
+++ b/cmake/LxQtTranslate.cmake
@@ -69,7 +69,7 @@ endif()
 
 function(lxqt_translate_ts _qmFiles)
     set(_translationDir "translations")
-    set(_installDir "${CMAKE_INSTALL_PREFIX}/share/lxqt/${PROJECT_NAME}")
+    set(_installDir "${LXQT_SHARE_DIR}/${PROJECT_NAME}")
     
     # Parse arguments ***************************************
     set(_state "")


### PR DESCRIPTION
LXQT_SHARE_DIR is defined with the "correct" value in lxqt-XXX-config.cmake.
Warning: It implies that liblxqt and each lxqt-runner have the same
install prefix.
