### PR TITLE
Adapt to the translation infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ if (MENU_CACHE_FOUND)
     add_definitions(-DHAVE_MENU_CACHE=1)
 endif (MENU_CACHE_FOUND)
 
+add_definitions(-DPROJECT_NAME=\"${PROJECT_NAME}\")
+
 set(lxqt-runner_H_FILES
     dialog.h
     commanditemmodel.h
@@ -119,6 +121,8 @@ lxqt_translate_ts(lxqt-runner_QM_FILES
         ${lxqt-runner_H_FILES}
         ${lxqt-runner_CPP_FILES} 
         ${lxqt-runner_UI_FILES}
+    INSTALLATION_DIR
+        ${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}
 )
 
 #************************************************

--- a/main.cpp
+++ b/main.cpp
@@ -27,8 +27,7 @@
 
 
 #include <LXQt/Application>
-// #include <LxQtTranslator>
-#include "lxqttranslate.h"
+#include <LXQt/Translator>
 #include "dialog.h"
 
 
@@ -37,9 +36,7 @@ int main(int argc, char *argv[])
     LxQt::Application a(argc, argv);
     a.setQuitOnLastWindowClosed(false);
 
-    TRANSLATE_APP;
-    // FIXME: we should deprecate LxQtTranslate
-    // LxQt::Translator::translateApplication("lxqt-runner");
+    LxQt::Translator::translateApplication(QLatin1String(PROJECT_NAME));
 
     QWidget *hiddenPreviewParent = new QWidget(0, Qt::Tool);
     Dialog d(hiddenPreviewParent);


### PR DESCRIPTION
Adapt to the changes in liblxqt. We now use the LxQt::Translator class to
load the translations. We save a few bytes ditching lxqttranslate.h
