### PR TITLE
Hide on loosing focus

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -182,8 +182,7 @@ bool Dialog::eventFilter(QObject *object, QEvent *event)
     }
     else if (event->type() == QEvent::FocusOut)
     {
-        QFocusEvent *focusEvent = static_cast<QFocusEvent*>(event);
-        focusOutEvent(focusEvent);
+        hide();
         return true;
     }
 
@@ -433,14 +432,6 @@ void Dialog::showConfigDialog()
     if (!mConfigureDialog)
         mConfigureDialog = new ConfigureDialog(mSettings, DEFAULT_SHORTCUT, this);
     mConfigureDialog->exec();
-}
-
-/************************************************
-
- ************************************************/
-void Dialog::focusOutEvent(QFocusEvent *e)
-{
-    hide();
 }
 
 #undef DEFAULT_SHORTCUT

--- a/dialog.h
+++ b/dialog.h
@@ -83,7 +83,6 @@ private:
 
     //! \brief handle various additional behaviours (math only for now)
     bool editEnterPressed();
-    bool focusOutEvent(QFocusEvent* e);
 
 private slots:
     void realign();


### PR DESCRIPTION
Hide runner when it looses focus.
All runners I know work like this. Besides, it is confusing if the
cursor still blinks but the window is not active anymore, so you think
you still type into runner but might not. Thus added hide upon loosing
focus.
