### PR TITLE
Add tab-completion

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -239,6 +239,12 @@ bool Dialog::editKeyPressEvent(QKeyEvent *event)
 
         qApp->sendEvent(ui->commandList, event);
         return true;
+
+    case Qt::Key_Tab:
+        const CommandProviderItem *command = mCommandItemModel->command(ui->commandList->currentIndex());
+        if (command)
+            ui->commandEd->setText(command->title());
+        return true;
     }
 
     return QDialog::eventFilter(ui->commandList, event);


### PR DESCRIPTION
when pressing tab, lxqt-runner completes to first entry in command list.
According to behaviour of dmenu and bash completion.
