### PR TITLE
Fixes Action button missing (menu) icon

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -108,7 +108,6 @@ Dialog::Dialog(QWidget *parent) :
     QMenu *menu = new QMenu(this);
     menu->addActions(actions());
     ui->actionButton->setMenu(menu);
-    ui->actionButton->setIcon(XdgIcon::fromTheme("configure"));
     // End of popup menu ........................
 
     applySettings();


### PR DESCRIPTION
We ship the icons with all themes (qss). Only a cosmic ray would make that
fail. We should not set an "fallback" in the code. That kind of
interactions are known to be undefined.

Closes lxde/lxqt#754