### PR TITLE
main: Add one shot option

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -50,6 +50,7 @@
 #include <QMenu>
 #include <QWindow>
 #include <QScrollBar>
+#include <QTimer>
 
 #include <KWindowSystem/KWindowSystem>
 
@@ -58,11 +59,12 @@
 /************************************************
 
  ************************************************/
-Dialog::Dialog(QWidget *parent) :
+Dialog::Dialog(bool oneShotShow, QWidget *parent) :
     QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint),
     ui(new Ui::Dialog),
     mSettings(new LXQt::Settings("lxqt-runner", this)),
     mGlobalShortcut(0),
+    mOneShotShow(oneShotShow),
     mLockCascadeChanges(false),
     mConfigureDialog(0)
 {
@@ -122,6 +124,8 @@ Dialog::Dialog(QWidget *parent) :
 
     // TEST
     connect(mCommandItemModel, SIGNAL(layoutChanged()), this, SLOT(dataChanged()));
+    if (mOneShotShow)
+        QTimer::singleShot(0, this, &QDialog::show);
 }
 
 
@@ -279,6 +283,13 @@ bool Dialog::listKeyPressEvent(QKeyEvent *event)
     }
 
     return QDialog::eventFilter(ui->commandEd, event);
+}
+
+void Dialog::hideEvent(QHideEvent * event)
+{
+    QDialog::hideEvent(event);
+    if (mOneShotShow)
+        close();
 }
 
 

--- a/dialog.h
+++ b/dialog.h
@@ -55,7 +55,7 @@ class Dialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit Dialog(QWidget *parent = 0);
+    explicit Dialog(bool oneShotShow, QWidget *parent = 0);
     ~Dialog();
 
     QSize sizeHint() const;
@@ -66,6 +66,7 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
     bool editKeyPressEvent(QKeyEvent *event);
     bool listKeyPressEvent(QKeyEvent *event);
+    void hideEvent(QHideEvent * event);
 
 private:
     Ui::Dialog *ui;
@@ -73,6 +74,7 @@ private:
     GlobalKeyShortcut::Action *mGlobalShortcut;
     CommandItemModel *mCommandItemModel;
     bool mShowOnTop;
+    bool mOneShotShow;
     int mMonitor;
     LXQt::PowerManager *mPowerManager;
     LXQt::ScreenSaver *mScreenSaver;

--- a/main.cpp
+++ b/main.cpp
@@ -26,19 +26,34 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 
-#include <LXQt/Application>
+#include <LXQt/SingleApplication>
+#include <QCommandLineParser>
 #include "dialog.h"
 
 
 int main(int argc, char *argv[])
 {
-    LXQt::Application a(argc, argv);
-    a.setQuitOnLastWindowClosed(false);
+    LXQt::SingleApplication a(argc, argv);
+    QCoreApplication::setApplicationName(QLatin1String("lxqt-runner"));
+    QCoreApplication::setApplicationVersion(LXQT_VERSION);
 
-    QWidget *hiddenPreviewParent = new QWidget(0, Qt::Tool);
-    Dialog d(hiddenPreviewParent);
-    //d.show();
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QLatin1String("LXQt runner"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption one_shot_run{QStringList() << QLatin1String("o") << QLatin1String("one-shot")
+            , QCoreApplication::translate("main", "Show the runner window for one shot (don't run as a daemon).")};
+
+    parser.addOption(one_shot_run);
+    parser.process(a);
+
+
+    QWidget hiddenPreviewParent{0, Qt::Tool};
+    const bool one_shot = parser.isSet(one_shot_run);
+    Dialog d(one_shot, &hiddenPreviewParent);
+    if (!one_shot)
+        a.setQuitOnLastWindowClosed(false);
 
     return a.exec();
-
 }


### PR DESCRIPTION
Add posibility to show the runner one time only (to be able to use it standalone w/o lxqt-globalkeysd)

closes lxde/lxqt#920