### PR TITLE
main: Add activation by running second instance

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -26,18 +26,18 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 
-#include <LXQt/Application>
+#include <LXQt/SingleApplication>
 #include "dialog.h"
 
 
 int main(int argc, char *argv[])
 {
-    LXQt::Application a(argc, argv);
+    LXQt::SingleApplication a(argc, argv);
     a.setQuitOnLastWindowClosed(false);
 
-    QWidget *hiddenPreviewParent = new QWidget(0, Qt::Tool);
-    Dialog d(hiddenPreviewParent);
-    //d.show();
+    QWidget hiddenPreviewParent{0, Qt::Tool};
+    Dialog d(&hiddenPreviewParent);
+    a.setActivationWindow(&d);
 
     return a.exec();
 


### PR DESCRIPTION
Use LXQt::SingleApplication to be able to activate/show window of the running daemon

This is another possibility for showing the runner by executing the `lxqt-runner` (first instance is running as a daemon and every next invocation just show the daemon's window)

This needs lxde/liblxqt#76

closes lxde/lxqt#920