### PR TITLE
Properly hide the runner when it loses focus

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -384,7 +384,7 @@ void Dialog::shortcutChanged(const QString &/*oldShortcut*/, const QString &newS
 void Dialog::onActiveWindowChanged(WId id)
 {
     if (isVisible() && id != winId())
-        showHide();
+        hide();
 }
 
 


### PR DESCRIPTION
`showHide` doesn't work for this because when it gets called the window
is no longer the active window, so instead of hiding it, it forces it
back as the active window.