### PR TITLE
Remove the dependency on QtScript and replace the math calculation with "bc".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ cmake_dependent_option(RUNNER_VBOX_HEADLESS
 find_package(KF5WindowSystem REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Xml REQUIRED)
-find_package(Qt5Script REQUIRED)
 find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(lxqt REQUIRED)
 find_package(lxqt-globalkeys REQUIRED)
@@ -32,7 +31,7 @@ message(STATUS "Building with Qt${Qt5Core_VERSION_STRING}")
 
 include(LXQtCompilerSettings NO_POLICY_SCOPE)
 
-set(QTX_LIBRARIES Qt5::Widgets Qt5::Xml Qt5::Script)
+set(QTX_LIBRARIES Qt5::Widgets Qt5::Xml)
 
 if (USE_MENU_CACHE)
     # optionally use libmenu-cache from lxde to generate the application menu

--- a/providers.h
+++ b/providers.h
@@ -256,6 +256,10 @@ public:
     bool run() const;
     bool compare(const QRegExp &regExp) const;
     virtual unsigned int rank(const QString &pattern) const;
+
+private:
+    mutable QString mCachedInput;
+    mutable QString mCachedResult;
 };
 
 


### PR DESCRIPTION
QtScript is deprecated. Since loading a full JS engine or the whole QML stack just for such a simple and probably less frequently used feature is not a good idea, I created this PR.
In this PR, I used an external calculator command "bc" to do the actual math.
Besides, I cached the calculated result to avoid duplicated calculation.
Pros:
* bc is a widely used and lightweight UNIX command, and it's powerful enough for this purpose.
* The tool bc only depends on libc.
* lxqt-runner no longer loads any scripting engine on startup. This helps both startup speed and memory usage. The code became cleaner as well. When the user does not use the feature, no memory usage is spent on the math part.
* bc won't be deprecated in the near future.
* KISS: This is the UNIX way. One tool for one thing.
* The bc syntax is in POSIX standard.

Cons:
* Add soft runtime dependency on "bc"

Since it's a common tool shipped by nearly all distros, I see this a much better fit than relying on specific libraries or bloated scripting engines.