### PR TITLE
runner: Follow virtual desktop switching

### DIFF
--- a/dialog.h
+++ b/dialog.h
@@ -78,6 +78,7 @@ private:
     LXQt::ScreenSaver *mScreenSaver;
 
     bool mLockCascadeChanges;
+    bool mDesktopChanged; //!< \note flag for changing desktop & activation workaround
 
     ConfigureDialog *mConfigureDialog;
 
@@ -91,6 +92,7 @@ private slots:
     void showConfigDialog();
     void shortcutChanged(const QString &oldShortcut, const QString &newShortcut);
     void onActiveWindowChanged(WId id);
+    void onCurrentDesktopChanged(int desktop);
 };
 
 #endif // DIALOG_H


### PR DESCRIPTION
If runner is shown and virtual desktop is changed, show/activate the runner there.

Addressing also the problem depicted by @pmattern in #43:
> ...the GUI of lxqt-runner is disappearing right after invoking here most of the time and in an unpredictable way (failed to figure out when this happens so far).

> The problem appears when the runner GUI was closed by hitting Esc without taking any action. E. g. start an LXQt session, launch the GUI by hitting Alt+F2 → everything fine. Close the GUI by hitting Esc without taking any action, open it again → disappears at once and continues to behave like this until the runner daemon is restarted.