### PR TITLE
- Fix endif placement when test for MATH library.

### DIFF
--- a/providers.cpp
+++ b/providers.cpp
@@ -885,6 +885,8 @@ MathProvider::MathProvider()
     append(new MathItem());
 }
 
+#endif
+
 ExternalProviderItem::ExternalProviderItem()
 {
 }
@@ -974,4 +976,3 @@ void ExternalProvider::readFromProcess()
     }
 }
 
-#endif


### PR DESCRIPTION
The wrong placement of the test is breaking compilations that do not use
muParser library