### PR TITLE
Fix pedantic warning

### DIFF
--- a/providers.cpp
+++ b/providers.cpp
@@ -810,7 +810,7 @@ static void muParserInitLocale()
 {
     MathItem::Parser::initLocale();
 }
-Q_COREAPP_STARTUP_FUNCTION(muParserInitLocale);
+Q_COREAPP_STARTUP_FUNCTION(muParserInitLocale)
 
 /************************************************
 


### PR DESCRIPTION
pkg-main/lxqt-runner/snapshot/providers.cpp:813:47: warning: extra ‘;’ [-Wpedantic]
 Q_COREAPP_STARTUP_FUNCTION(muParserInitLocale);