### PR TITLE
Start calculator also on numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-lxqt-runner provides a GUI that comes up on the desktop and allows for launching applications or shutting down the system. A calculator function is implemented too.
+lxqt-runner provides a desktop GUI for launching applications or shutting down the system. It also includes a calculator, which is triggered by entering = or a sequence of numbers and operators.
 
 ![lxqt-runner](lxqt-runner.png)
 

--- a/providers.cpp
+++ b/providers.cpp
@@ -827,6 +827,11 @@ bool MathItem::compare(const QRegularExpression &regExp) const
         s.chop(1);
     }
 
+    QRegularExpression mathPattern(QStringLiteral("^[0-9+\\-*/ ]+$"));
+    if (mathPattern.match(s).hasMatch()) {
+        is_math = true;
+    }
+
     if (is_math)
     {
         if (s != mCachedInput)

--- a/providers.cpp
+++ b/providers.cpp
@@ -821,14 +821,15 @@ bool MathItem::compare(const QRegularExpression &regExp) const
         is_math = true;
         s.remove(0, 1);
     }
+
     if (s.endsWith(QLatin1Char('=')))
     {
         is_math = true;
         s.chop(1);
     }
 
-    QRegularExpression mathPattern(QStringLiteral("^[0-9+\\-*/ ]+$"));
-    if (mathPattern.match(s).hasMatch()) {
+    if (!s.isEmpty() && s.at(0).isDigit())
+    {
         is_math = true;
     }
 


### PR DESCRIPTION
While looking if it would be possible to show results also on `KP_Enter` and `Return` (which seems quite hard to implement) I noticed that the calculator shows results in realtime by entering "=" `before`, afaik that is undocumented (for all the years I had to press = (shift+0) which wasn't convenient).

With this PR   the calculator will start also when entering numbers and an operator and act the same as when "=" is inserted.

<img width="467" height="395" alt="immagine" src="https://github.com/user-attachments/assets/1cc12592-2403-49ea-848b-c9433671b2ff" />
